### PR TITLE
Bug fix: MaxClients not set from MAX_CLIENTS env var

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -36,6 +36,7 @@ CMD set -eu; \
         cp /etc/tinyproxy/tinyproxy.default.conf "$CONFIG"; \
         ([ -z "$DISABLE_VIA_HEADER" ] || sed -i "s|^#DisableViaHeader .*|DisableViaHeader Yes|" "$CONFIG"); \
         ([ -z "$STAT_HOST" ]          || sed -i "s|^#StatHost .*|StatHost \"${STAT_HOST}\"|" "$CONFIG"); \
+        ([ -z "$MAX_CLIENTS" ]        || sed -i "s|^MaxClients .*|MaxClients $MAX_CLIENTS|" "$CONFIG"); \
         ([ -z "$MIN_SPARE_SERVERS" ]  || sed -i "s|^MinSpareServers .*|MinSpareServers $MIN_SPARE_SERVERS|" "$CONFIG"); \
         ([ -z "$MIN_SPARE_SERVERS" ]  || sed -i "s|^StartServers .*|StartServers $MIN_SPARE_SERVERS|" "$CONFIG"); \
         ([ -z "$MAX_SPARE_SERVERS" ]  || sed -i "s|^MaxSpareServers .*|MaxSpareServers $MAX_SPARE_SERVERS|" "$CONFIG"); \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -39,6 +39,7 @@ ENTRYPOINT set -eu; \
                cp /etc/tinyproxy/tinyproxy.default.conf "$CONFIG"; \
                ([ -z "$DISABLE_VIA_HEADER" ] || sed -i "s|^#DisableViaHeader .*|DisableViaHeader Yes|" "$CONFIG"); \
                ([ -z "$STAT_HOST" ]          || sed -i "s|^#StatHost .*|StatHost \"${STAT_HOST}\"|" "$CONFIG"); \
+               ([ -z "$MAX_CLIENTS" ]        || sed -i "s|^MaxClients .*|MaxClients $MAX_CLIENTS|" "$CONFIG"); \
                ([ -z "$MIN_SPARE_SERVERS" ]  || sed -i "s|^MinSpareServers .*|MinSpareServers $MIN_SPARE_SERVERS|" "$CONFIG"); \
                ([ -z "$MIN_SPARE_SERVERS" ]  || sed -i "s|^StartServers .*|StartServers $MIN_SPARE_SERVERS|" "$CONFIG"); \
                ([ -z "$MAX_SPARE_SERVERS" ]  || sed -i "s|^MaxSpareServers .*|MaxSpareServers $MAX_SPARE_SERVERS|" "$CONFIG"); \


### PR DESCRIPTION
Small bug fix: `MAX_CLIENTS` is listed in the dockerfile as an accepted env var and also used in the sample docker-compose yaml but `MaxClients` wasn't being set in the config file.