### PR TITLE
Add info to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       # AUTH_USER: ''
       # Prefer secrets-mechanisms instead of environment variables.
       # AUTH_PASSWORD: ''
+      # Password for BasicAuth (letters and digits only)
     # secrets:
     #   - auth_password
     # # With Alpine base image, this is required, for some reason, or /run/secrets won't get mounted.


### PR DESCRIPTION
Implementation can't parse special chars in BasicAuth. Added an info at docker-compose.yml to only use letters and digits in AUTH_PASSWORD environment variable.